### PR TITLE
PhotoOutput now has public 'avCapturePhotoOutput',

### DIFF
--- a/Capturer/Basic/CaptureBody.swift
+++ b/Capturer/Basic/CaptureBody.swift
@@ -14,6 +14,8 @@ public final class CaptureBodyWrapper: @unchecked Sendable {
 
       public var sessionPreset: AVCaptureSession.Preset = .photo
 
+      public var enableMultitaskingCameraAccessIfSupported: Bool = false
+        
       public init() {
 
       }
@@ -63,6 +65,10 @@ public final class CaptureBodyWrapper: @unchecked Sendable {
       self.session.performConfiguration {
         $0.sessionPreset = configuration.sessionPreset
         $0.automaticallyConfiguresCaptureDeviceForWideColor = true
+          if configuration.enableMultitaskingCameraAccessIfSupported,
+             $0.isMultitaskingCameraAccessSupported {
+              $0.isMultitaskingCameraAccessEnabled = true
+          }
       }
 
     }

--- a/Capturer/Basic/Outputs/PhotoOutput.swift
+++ b/Capturer/Basic/Outputs/PhotoOutput.swift
@@ -32,6 +32,7 @@ public final class PhotoOutput: _StatefulObjectBase, OutputNodeType, @unchecked 
   }
 
   private let _output = AVCapturePhotoOutput()
+  public var avCapturePhotoOutput: AVCapturePhotoOutput { _output }
 
   public init(quality: AVCapturePhotoOutput.QualityPrioritization = .balanced) {
     super.init()

--- a/Capturer/Basic/PhotoTools.swift
+++ b/Capturer/Basic/PhotoTools.swift
@@ -4,7 +4,7 @@ import UIKit
 enum PhotoTools {
 
   @MainActor
-  public static func save(image: UIImage, completion: @escaping (Result<Void, Error>) -> Void) {
+  public static func save(image: UIImage, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
 
     PHPhotoLibrary.shared().performChanges {
 

--- a/Capturer/Basic/Views/PixelBufferView.swift
+++ b/Capturer/Basic/Views/PixelBufferView.swift
@@ -36,8 +36,8 @@ public final class PixelBufferView: UIView, PixelBufferDisplaying {
       subscription = await output
         .pixelBufferBus
         .addHandler { [unowned self] pixelBuffer in
-          Task {
-            await self.input(pixelBuffer: pixelBuffer)
+          Task { @MainActor [unowned self] in
+            self.input(pixelBuffer: pixelBuffer)
           }
         }
     }

--- a/Capturer/Basic/Views/PixelBufferView.swift
+++ b/Capturer/Basic/Views/PixelBufferView.swift
@@ -32,14 +32,15 @@ public final class PixelBufferView: UIView, PixelBufferDisplaying {
 
     subscription?.cancel()
 
-    Task {
-      subscription = await output
+    Task { [weak self] in
+      let subscription = await output
         .pixelBufferBus
-        .addHandler { [unowned self] pixelBuffer in
-          Task { @MainActor [unowned self] in
-            self.input(pixelBuffer: pixelBuffer)
+        .addHandler { [weak self] pixelBuffer in
+          Task { @MainActor in
+            self?.input(pixelBuffer: pixelBuffer)
           }
         }
+      self?.subscription = subscription
     }
   }
 

--- a/Capturer/Extended/Filters/CoreImageFilter.swift
+++ b/Capturer/Extended/Filters/CoreImageFilter.swift
@@ -2,7 +2,7 @@
 import Foundation
 import CoreImage
 
-open class CoreImageFilter: CVPixelBufferModifying {
+open class CoreImageFilter: CVPixelBufferModifying, @unchecked Sendable {
 
   private lazy var ciContext = MTLCreateSystemDefaultDevice()
     .map {


### PR DESCRIPTION
Added `avCapturePhotoOutput` to `PhotoOutput` so you can more reasonably configure your settings during capture, including information like `isShutterSoundSuppressionSupported`.

Added public access to AVCapturePhotoOutput.  Why?

My app wanted to set the option in AVCaptureSettings of `isShutterSoundSuppressionEnabled` to `true`, but this resulted in a crash for some users with the error:

> Fatal Exception: NSInvalidArgumentException
> *** -[AVCapturePhotoOutput capturePhotoWithSettings:delegate:] settings.shutterSoundSuppressionEnabled may not be set to YES unless self.shutterSoundSuppressionSupported is YES

I didn't rename anything, but just added this extra public,