### PR TITLE
Added `enableMultitaskingCameraAccessIfSupported` configuration flag

### DIFF
--- a/Capturer/Basic/CaptureBody.swift
+++ b/Capturer/Basic/CaptureBody.swift
@@ -14,6 +14,8 @@ public final class CaptureBodyWrapper: @unchecked Sendable {
 
       public var sessionPreset: AVCaptureSession.Preset = .photo
 
+      public var enableMultitaskingCameraAccessIfSupported: Bool = false
+        
       public init() {
 
       }
@@ -63,6 +65,10 @@ public final class CaptureBodyWrapper: @unchecked Sendable {
       self.session.performConfiguration {
         $0.sessionPreset = configuration.sessionPreset
         $0.automaticallyConfiguresCaptureDeviceForWideColor = true
+          if configuration.enableMultitaskingCameraAccessIfSupported,
+             $0.isMultitaskingCameraAccessSupported {
+              $0.isMultitaskingCameraAccessEnabled = true
+          }
       }
 
     }


### PR DESCRIPTION
Ran into the issue recently of camera preview suddenly stopping on iPads running in anything less than full screen. Ran into this on iPadOS 26, but it should also apply to iPadOS 17 and iPadOS 18. Adds configuration flag, `enableMultitaskingCameraAccessIfSupported` to enable camera access while in other than full screen.